### PR TITLE
Added JUnit5 to examples

### DIFF
--- a/basic_example/pom.xml
+++ b/basic_example/pom.xml
@@ -12,6 +12,10 @@
     <name>YDB Basic Example</name>
     <description>Simple example of usage Java SDK for YDB</description>
 
+    <properties>
+        <junit5.version>5.10.1</junit5.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>tech.ydb</groupId>
@@ -34,6 +38,13 @@
         <dependency>
             <groupId>tech.ydb.test</groupId>
             <artifactId>ydb-junit5-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jdbc/spring-data-jpa-v5/pom.xml
+++ b/jdbc/spring-data-jpa-v5/pom.xml
@@ -66,20 +66,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>tech.ydb.test</groupId>
-            <artifactId>ydb-junit5-support</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>tech.ydb.test</groupId>
+            <artifactId>ydb-junit5-support</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/url-shortener-demo/pom.xml
+++ b/url-shortener-demo/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <jetty.version>10.0.14</jetty.version>
         <gson.version>2.9.0</gson.version>
+        <junit5.version>5.10.1</junit5.version>
     </properties>
 
     <dependencies>
@@ -51,6 +52,13 @@
         <dependency>
             <groupId>tech.ydb.test</groupId>
             <artifactId>ydb-junit5-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
To avoid conflict with predefined JUnit5 from various dependencies (like spring-boot-test-starter) now we require to specify JUnit5 version directly in every pom.xml