### PR TITLE
Fix Dockerfile.sdk export stage

### DIFF
--- a/slo-workload/docker/Dockerfile.sdk
+++ b/slo-workload/docker/Dockerfile.sdk
@@ -33,7 +33,7 @@ RUN SDK_VERSION="$(cat /tmp/sdk.version)" && \
         -Dmaven.javadoc.skip=true \
         package
 
-FROM ${MAVEN_IMAGE} AS export
+FROM workload-build AS export
 ARG WORKLOAD_MODULE
 ARG WORKLOAD_JAR
 ARG COPY_LIBS


### PR DESCRIPTION
## Summary
- `export` stage must inherit from `workload-build`, not a fresh Maven image
- Without this, packaged workload jars are missing and java-sdk SLO matrix fails

## Test plan
- [ ] Re-run SLO on ydb-java-sdk #668

Made with [Cursor](https://cursor.com)